### PR TITLE
Add link to imgclsmob repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - [PyTorch Tutorials](https://chsasank.github.io/pytorch-tutorials/index.html): PyTorch tutorials better rendered with readthedocs style
 - [t-SNE experiments in pytorch](https://github.com/cemoody/topicsne): A simple t-SNE model implemented in pytorch
 - [Welcome tutorials](https://github.com/mila-udem/welcome_tutorials/tree/master/pytorch): MILA's pytorch tutorials
+- [image-classification-mobile](https://github.com/osmr/imgclsmob): Examples of reproducible training various classification models for ImageNet-1K
 
 ## Blog & Article
 


### PR DESCRIPTION
Add, please, a link to the `imgclsmob` repo with a collection of classification models, most of which are pretrained on the ImageNet dataset. The repo contains scripts for training / testing models, and for converting them from other frameworks.